### PR TITLE
Deleted random quotations in index.html

### DIFF
--- a/Develop/index.html
+++ b/Develop/index.html
@@ -1,4 +1,4 @@
-"<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en-us">
 
 <head>
@@ -82,4 +82,3 @@
 </body>
 
 </html>
-"


### PR DESCRIPTION
Bug: quotations at the beginning and end of the index.html. This caused the website to have random quotes at the top and bottom of the web page
Fix: removed quotes from top and bottom of index.html